### PR TITLE
Fix socket.io service instance retrieval

### DIFF
--- a/src/services/socket.io.js
+++ b/src/services/socket.io.js
@@ -1,13 +1,16 @@
 import { Server } from "socket.io";
 // const stack = require('src/static/stack')
 
-const io = () => {
-  return io;
-};
+// Hold a reference to the socket.io instance once initialized
+let ioInstance;
 
+// Return the socket.io instance for use in other modules
+const io = () => ioInstance;
+
+// Initialize the socket.io server and store the instance
 const init = (server) => {
-  const io = new Server(server, { cors: { origin: "*" } });
-  io.on("connection", (socket) => {
+  ioInstance = new Server(server, { cors: { origin: "*" } });
+  ioInstance.on("connection", (socket) => {
     console.log(socket.id);
     socket.on("disconnect", () => {
       console.log(`${socket.id} is disconnected!`);
@@ -20,7 +23,7 @@ const init = (server) => {
     });
   });
 
-  return io;
+  return ioInstance;
 };
 
 export default { io, init };

--- a/src/test.js
+++ b/src/test.js
@@ -1,7 +1,16 @@
-import { enCryptPassword } from "./modules/authentication/authentication.methods.js";
+import socket from "./services/socket.io.js";
+import { createServer } from "http";
 
 async function test() {
-  const pass = await enCryptPassword("tieptan");
-  console.log(pass);
+  const httpServer = createServer();
+  await new Promise((resolve) => httpServer.listen(0, resolve));
+  const ioServer = socket.init(httpServer);
+  if (socket.io() !== ioServer) {
+    throw new Error("Socket.io instance was not initialized correctly");
+  }
+  console.log("Socket.io service initialized correctly");
+  ioServer.close();
+  httpServer.close();
 }
+
 test();


### PR DESCRIPTION
## Summary
- ensure socket.io service stores and exposes the initialized Server instance
- add test to validate socket.io instance retrieval

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error: Unexpected token : and unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_6898210828cc832dac149bc2884ed99f