### PR TITLE
Fix password hashing and socket service

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ const startServer = async () => {
     await sequelize.authenticate();
     console.log("Database connected!");
     const PORT = process.env.PORT || 8080;
-    server.listen(PORT, (req, res) => {
+    server.listen(PORT, () => {
       console.log(`APP RUNNING AT PORT ${PORT}`);
     });
   } catch (error) {
@@ -31,7 +31,7 @@ const startServer = async () => {
 startServer().then(() => {
   socket.init(server);
   app.use((req, res, next) => {
-    req.io = socket.io();
+    req.io = socket.getIO();
     return next();
   });
   app.use("/", mainRouter);

--- a/src/modules/authentication/authentication.methods.js
+++ b/src/modules/authentication/authentication.methods.js
@@ -2,19 +2,15 @@ import bcrypt from "bcrypt";
 import jwt from "jsonwebtoken";
 import { ERROR_MESSAGE } from "../../services/customError.js";
 
-//TODO fix bug
-export const enCryptPassword = (password) => {
-  const saltRounds = process.env.SALT_ROUNDS || 10;
-  bcrypt
-    .hash(password, saltRounds)
-    .then((result) => {
-      console.log(result);
-      return result;
-    })
-    .catch((err) => {
-      console.log(err);
-      throw ERROR_MESSAGE.serverError;
-    });
+export const enCryptPassword = async (password) => {
+  const saltRounds = parseInt(process.env.SALT_ROUNDS) || 10;
+  try {
+    const hash = await bcrypt.hash(password, saltRounds);
+    return hash;
+  } catch (err) {
+    console.log(err);
+    throw ERROR_MESSAGE.serverError;
+  }
 };
 
 export const comparePassword = async (plainPassword, hashPassword) => {

--- a/src/modules/doctor/doctor.controllers.js
+++ b/src/modules/doctor/doctor.controllers.js
@@ -44,7 +44,7 @@ const controller = () => {
         });
         await prescription.save();
         const items = req.body.PRESCRIPTION;
-        items.map(async (item) => {
+        for (const item of items) {
           const prescription_item = new PRESCRIPTION_ITEM({
             PRESCRIPTION_ID: prescription.PRESCRIPTION_ID,
             DRUG_NAME: item.DRUG_NAME,
@@ -52,7 +52,7 @@ const controller = () => {
             INSTRUCTION: item.INSTRUCTION,
           });
           await prescription_item.save();
-        });
+        }
         diagnostic.SYMPTOM = req.body.SYMPTOM;
         diagnostic.PRESCRIPTION = prescription.PRESCRIPTION_ID;
         // diagnostic.RE_EXAMINATION = req.body.RE_EXAMINATION
@@ -76,7 +76,7 @@ const controller = () => {
     }
   };
 
-  const getStackByRoom = (req, res) => {};
+  const getStackByRoom = () => {};
 
   return {
     getRoom,

--- a/src/modules/manager/manager.controllers.js
+++ b/src/modules/manager/manager.controllers.js
@@ -1,7 +1,7 @@
 import database from "../../models/index.js";
 import { enCryptPassword } from "../authentication/authentication.methods.js";
 
-const { sequelize, EMPLOYEE, SERVICE, ACCOUNT } = database;
+const { EMPLOYEE, SERVICE, ACCOUNT } = database;
 
 import moment from "moment";
 const controller = () => {
@@ -21,10 +21,11 @@ const controller = () => {
       });
       await employee.save();
 
+      const hashedPassword = await enCryptPassword(req.body.PASSWORD);
       const account = new ACCOUNT({
         EMPLOYEE_ID: employee.EMPLOYEE_ID,
         USERNAME: req.body.USERNAME,
-        PASSWORD: enCryptPassword(req.body.PASSWORD),
+        PASSWORD: hashedPassword,
         ISACTIVE: true,
         ROLE: req.body.POSITION,
       });

--- a/src/modules/user/user.controllers.js
+++ b/src/modules/user/user.controllers.js
@@ -57,17 +57,18 @@ const controller = () => {
   const changPassword = async (req, res) => {
     console.log(req.userInfo);
     try {
+      const oldPassHash = await enCryptPassword(req.body.oldPass);
       const account = await ACCOUNT.findOne({
         where: {
           [Op.and]: [
             { USERNAME: req.userInfo.username },
-            { PASSWORD: enCryptPassword(req.body.oldPass) },
+            { PASSWORD: oldPassHash },
           ],
         },
       });
       if (!account) return res.status(409).send("Sai mật khẩu");
       console.log(account);
-      account.PASSWORD = enCryptPassword(req.body.newPass);
+      account.PASSWORD = await enCryptPassword(req.body.newPass);
       await account.save();
       return res.send("Đổi mật khẩu thành công");
     } catch (error) {

--- a/src/services/databaseServices/appointment.services.js
+++ b/src/services/databaseServices/appointment.services.js
@@ -23,8 +23,21 @@ class AppointmentService {
   }
 
   async createAppointMent(appointmentInfo) {
+    const requiredFields = [
+      "CREATE_AT",
+      "TIME",
+      "PATIENT_ID",
+      "TYPE_ID",
+      "STATUS_ID",
+      "DOCTOR_ID",
+    ];
+    for (const field of requiredFields) {
+      if (!appointmentInfo[field]) {
+        throw ERROR_MESSAGE.emptyRequestBody;
+      }
+    }
     try {
-      const appointment = new APPOINTMENT({ appointmentInfo });
+      const appointment = new APPOINTMENT(appointmentInfo);
       await appointment.save();
       return appointment;
     } catch (error) {

--- a/src/services/socket.io.js
+++ b/src/services/socket.io.js
@@ -1,12 +1,9 @@
 import { Server } from "socket.io";
-// const stack = require('src/static/stack')
 
-const io = () => {
-  return io;
-};
+let io;
 
 const init = (server) => {
-  const io = new Server(server, { cors: { origin: "*" } });
+  io = new Server(server, { cors: { origin: "*" } });
   io.on("connection", (socket) => {
     console.log(socket.id);
     socket.on("disconnect", () => {
@@ -23,4 +20,6 @@ const init = (server) => {
   return io;
 };
 
-export default { io, init };
+const getIO = () => io;
+
+export default { init, getIO };

--- a/src/static/stack.js
+++ b/src/static/stack.js
@@ -1,13 +1,12 @@
 import database from "../models/index.js";
 
-const { sequelize, APPOINTMENT } = database;
+const { sequelize } = database;
 import { dateParse, today } from "../constants/date.js";
-import { QueryTypes, or } from "sequelize";
+import { QueryTypes } from "sequelize";
 import socket from "../services/socket.io.js";
-const io = socket.io;
 
 const emitChange = () => {
-  io().emit("diagnostic-stack-change", {
+  socket.getIO().emit("diagnostic-stack-change", {
     room1: room1.getPatientStack(),
     room2: room2.getPatientStack(),
   });
@@ -50,7 +49,7 @@ class Stack {
     return this.order;
   }
 
-  changeTime(pnum, time) {}
+  changeTime() {}
   changeStatus(order, status) {
     // if (this.patientStack[order] && this.patientStack[order] != 'appointment') {
     //     this.patientStack[order].status = status
@@ -75,15 +74,15 @@ class Stack {
   }
 
   async initAppointment() {
-    let appointmentToday = await sequelize.query(
+    const appointmentToday = await sequelize.query(
       `select * from appointment WHERE CONVERT(VARCHAR(10), TIMES, 103) = ?`,
       {
         replacements: [dateParse(new Date())],
         type: QueryTypes.SELECT,
-      }
+      },
     );
     appointmentToday.map((appointment) => {
-      let date = new Date();
+      const date = new Date();
       date.setHours(appointment.TIMES.getUTCHours());
       date.setMinutes(appointment.TIMES.getUTCMinutes());
       date.setSeconds(appointment.TIMES.getUTCSeconds());


### PR DESCRIPTION
## Summary
- return hash from `enCryptPassword` and await calls
- maintain single socket.io instance with `getIO`
- validate appointment data and save prescription items sequentially

## Testing
- `npx eslint src/modules/authentication/authentication.methods.js src/modules/user/user.controllers.js src/modules/manager/manager.controllers.js src/services/socket.io.js src/index.js src/static/stack.js src/services/databaseServices/appointment.services.js src/modules/doctor/doctor.controllers.js && echo "eslint success"`


------
https://chatgpt.com/codex/tasks/task_e_68982223bed0832d8d326018e6b306d9