### PR TITLE
feat: add api interfaces

### DIFF
--- a/src/interfaces/auth.interface.ts
+++ b/src/interfaces/auth.interface.ts
@@ -1,0 +1,9 @@
+export interface LoginRequest {
+  username: string;
+  password: string;
+}
+
+export interface LoginResponse {
+  access_token: string;
+}
+

--- a/src/interfaces/customer.interface.ts
+++ b/src/interfaces/customer.interface.ts
@@ -1,0 +1,19 @@
+export interface PatientInfo {
+  patientName: string;
+  identityNumber: string;
+  phone: string;
+  gender: string;
+  dateOfBirth: string;
+  address: string;
+}
+
+export interface AppointmentInfo {
+  doctorId: number;
+  time: string;
+}
+
+export interface AppointmentRequestPayload {
+  patient: PatientInfo;
+  appointment: AppointmentInfo;
+}
+

--- a/src/interfaces/user.interface.ts
+++ b/src/interfaces/user.interface.ts
@@ -1,0 +1,15 @@
+export interface UpdateProfileRequest {
+  employeeName?: string;
+  identityNumber?: string;
+  phone?: string;
+  gender?: string;
+  dateOfBirth?: string;
+  employeeAddress?: string;
+  positionId?: number;
+}
+
+export interface ChangePasswordRequest {
+  oldPass: string;
+  newPass: string;
+}
+

--- a/src/modules/authentication/authentication.controllers.ts
+++ b/src/modules/authentication/authentication.controllers.ts
@@ -4,9 +4,10 @@ import {
 } from "./authentication.methods.js";
 import { AccountServices } from "../../services/databaseServices/account.services.js";
 import { errorMessage } from "../../services/customError.js";
+import type { LoginRequest } from "../../interfaces/auth.interface.js";
 
 const handleLogin = async (req, res, next) => {
-  const { username, password } = req.body;
+  const { username, password } = req.body as LoginRequest;
   try {
     const account = await AccountServices.instance.findAccoutByUsername(
       username,

--- a/src/modules/customer/customer.controller.ts
+++ b/src/modules/customer/customer.controller.ts
@@ -1,11 +1,13 @@
 import database from "../../models/index.js";
-const { APPOINTMENTREQUEST, Patient } = database;
+const { APPOINTMENTREQUEST } = database;
 import moment from "moment";
+import type { AppointmentRequestPayload } from "../../interfaces/customer.interface.js";
+
 const controller = () => {
   const createAppointmentRequest = async (req, res) => {
     console.log(req.body);
-    const patientData = req.body.patient;
-    const appointmentData = req.body.appointment;
+    const { patient: patientData, appointment: appointmentData } =
+      req.body as AppointmentRequestPayload;
     try {
       const request = new APPOINTMENTREQUEST({
         createAt: new Date(),

--- a/src/modules/user/user.controllers.ts
+++ b/src/modules/user/user.controllers.ts
@@ -2,6 +2,10 @@ import database from "../../models/index.js";
 import { enCryptPassword } from "../authentication/authentication.methods.js";
 import { Op } from "sequelize";
 import moment from "moment";
+import type {
+  UpdateProfileRequest,
+  ChangePasswordRequest,
+} from "../../interfaces/user.interface.js";
 
 const { Employee, Account, ROOM, SERVICE } = database;
 
@@ -25,27 +29,28 @@ const controller = () => {
 
   const updateProfileById = async (req, res) => {
     try {
+      const requestBody = req.body as UpdateProfileRequest;
       const id = req.userInfo.employee_id;
       const user = await Employee.findOne({
         where: { employeeId: id },
       });
       if (user) {
-        user.employeeName = req.body.employeeName
-          ? req.body.employeeName
+        user.employeeName = requestBody.employeeName
+          ? requestBody.employeeName
           : user.employeeName;
-        user.identityNumber = req.body.identityNumber
-          ? req.body.identityNumber
+        user.identityNumber = requestBody.identityNumber
+          ? requestBody.identityNumber
           : user.identityNumber;
-        user.phone = req.body.phone ? req.body.phone : user.phone;
-        user.gender = req.body.gender ? req.body.gender : user.gender;
-        user.dateOfBirth = req.body.dateOfBirth
-          ? moment(req.body.dateOfBirth, "DD/MM/YYYY")
+        user.phone = requestBody.phone ? requestBody.phone : user.phone;
+        user.gender = requestBody.gender ? requestBody.gender : user.gender;
+        user.dateOfBirth = requestBody.dateOfBirth
+          ? moment(requestBody.dateOfBirth, "DD/MM/YYYY")
           : user.dateOfBirth;
-        user.employeeAddress = req.body.employeeAddress
-          ? req.body.employeeAddress
+        user.employeeAddress = requestBody.employeeAddress
+          ? requestBody.employeeAddress
           : user.employeeAddress;
-        user.positionId = req.body.positionId
-          ? req.body.positionId
+        user.positionId = requestBody.positionId
+          ? requestBody.positionId
           : user.positionId;
         await user.save();
         return res.status(200).send("Cập nhật thành công!");
@@ -59,7 +64,8 @@ const controller = () => {
   const changPassword = async (req, res) => {
     console.log(req.userInfo);
     try {
-      const oldPassHash = await enCryptPassword(req.body.oldPass);
+      const body = req.body as ChangePasswordRequest;
+      const oldPassHash = await enCryptPassword(body.oldPass);
       const account = await Account.findOne({
         where: {
           [Op.and]: [
@@ -70,7 +76,7 @@ const controller = () => {
       });
       if (!account) return res.status(409).send("Sai mật khẩu");
       console.log(account);
-      account.password = await enCryptPassword(req.body.newPass);
+      account.password = await enCryptPassword(body.newPass);
       await account.save();
       return res.send("Đổi mật khẩu thành công");
     } catch (error) {


### PR DESCRIPTION
## Summary
- define interfaces for authentication, customer appointment, and user profile APIs
- use typed request bodies in related controllers

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_68983497b6e8832d83b6dfdb7548719e